### PR TITLE
Fix WindowsCovering build for esp-idf v5.3 toolchain

### DIFF
--- a/components/button/button_driver.c
+++ b/components/button/button_driver.c
@@ -107,7 +107,7 @@ static bool hp_gpio_intr_handler_registered = false;
 
 static int hp_gpio_sw_intr_handler(void *arg)
 {
-    uint32_t *pin_mask = (uint32_t*) esp_amp_sys_info_get(0x00, NULL);
+    uint32_t *pin_mask = (uint32_t*) esp_amp_sys_info_get(0x00, NULL, SYS_INFO_CAP_HP);
     button_driver_isr_handler(pin_mask);
     return 0;
 }

--- a/components/light/led/led_driver.c
+++ b/components/light/led/led_driver.c
@@ -60,7 +60,7 @@ int led_driver_set_channel(uint8_t channel, uint8_t val)
     ledc_ll_set_hpoint(&LEDC, speed_mode, channel, hpoint);
     /* LEDC_CHn_DUTY: config duty */
     ledc_ll_set_duty_int_part(&LEDC, speed_mode, channel, (LEDC_MAX_DUTY * val / 100));
-    ledc_ll_set_duty_start(&LEDC, speed_mode, channel, true);
+    ledc_ll_set_duty_start(&LEDC, speed_mode, channel);
     /* LEDC_PARA_UP_CHn: enable the configuration above */
     if (speed_mode == LEDC_LOW_SPEED_MODE) {
         ledc_ll_ls_channel_update(&LEDC, speed_mode, channel);
@@ -114,7 +114,6 @@ void led_driver_deinit(void)
     for (int ch=LED_CHANNEL_NC+1; ch<LED_CHANNEL_MAX; ch++) {
         if (channel_mask | BIT(ch)) {
             ledc_ll_set_sig_out_en(&LEDC, speed_mode, ch, false);
-            ledc_ll_set_duty_start(&LEDC, speed_mode, ch, false);
             if (speed_mode == LEDC_LOW_SPEED_MODE) {
                 ledc_ll_ls_channel_update(&LEDC, speed_mode, ch);
             }


### PR DESCRIPTION
## Summary
- update the button driver to use the new `esp_amp_sys_info_get` signature with the correct capability flag
- align the LED driver with the latest LEDC low-level API changes so duty updates compile on esp-idf v5.3

## Testing
- `idf.py build` (from `products/WindowsCovering`)


------
https://chatgpt.com/codex/tasks/task_e_68cd1a426f7c83308f281aa3f3f5e784